### PR TITLE
fix: no return after if

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ hexo.extend.filter.register('after_render:html', (str, data) => {
     log.debug('postfilter: '+s);
     return s;
   }
+  return str;
 })
 
 


### PR DESCRIPTION
Related issues:
> https://github.com/EYHN/hexo-helper-live2d/issues/91

https://github.com/MoePlayer/hexo-tag-dplayer/blob/master/index.js#L65
`hexo.extend.filter.register`在`(str.includes('</html>') && str.includes('class="dplayer hexo-tag-dplayer-mark"')) === false` 的情况下会丢失返回值。

根据https://hexo.io/zh-cn/api/filter.html中的说明:
> data 会作为第一个参数传入每个过滤器，而您可以在过滤器中通过返回值改变下一个过滤器中的 data，如果什么都没有返回的话则会保持原本的 data。
https://github.com/hexojs/hexo/blob/master/lib/extend/filter.js#L63

丢失返回值将会导致接下来的所有过滤器所做的改动无法应用到生成的文件中。